### PR TITLE
chore: add common Python and OS entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
 lightscope-private.pem
+
+# OS
+.DS_Store
+
+# Python
+__pycache__/
+*.pyc
+*.egg-info/
+
+# Build artifacts
+dist/
+build/


### PR DESCRIPTION
Adds standard ignore patterns for Python projects and macOS.

Entries added:
- `.DS_Store` (macOS metadata)
- `__pycache__/`, `*.pyc` (Python bytecode)
- `*.egg-info/` (Python package metadata)
- `dist/`, `build/` (build artifacts)

Related to #6.